### PR TITLE
[automake]: Add inspec tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# automake
+
+A tool for automatically generating Makefile.in files compliant with the GNU Coding Standards
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+Typically this is a build time dependency that can be added to your
+plan.sh:
+
+    pkg_build_deps=(core/automake)
+
+## TODO
+
+`make check` do not pass all tests, here are the ones that fail as of 2017-12-13:
+
+* t/amopts-location.sh
+* t/add-missing-install-sh.sh
+* t/javadir-undefined.sh
+* t/java-mix.sh
+* t/lex-depend.sh
+* t/location.sh
+* t/preproc-errmsg.sh
+* t/repeated-options.sh
+* t/src-acsubst.sh
+* t/vars3.sh
+* t/warnopts.sh
+* t/warnings-win-over-strictness.sh
+* t/yflags-conditional.sh
+
+Also, note that this test suite is designed with many compilers/interpreters in mind (eg: java, python)
+making them all pass seem not possible/desirable.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.automake?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+
 # automake
 
 A tool for automatically generating Makefile.in files compliant with the GNU Coding Standards

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,1 +1,1 @@
-command_relative_path: '/bin/automake'
+command_relative_path: 'bin/automake'

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+command_relative_path: '/bin/automake'

--- a/controls/automake_exists.rb
+++ b/controls/automake_exists.rb
@@ -7,7 +7,8 @@ control 'core-plans-automake-exists' do
   impact 1.0
   title 'Ensure automake exists'
   desc '
-  '
+  Verify automake by ensuring /bin/automake exists'
+  
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }

--- a/controls/automake_exists.rb
+++ b/controls/automake_exists.rb
@@ -13,6 +13,7 @@ control 'core-plans-automake-exists' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
   end
 
   command_relative_path = input('command_relative_path', value: 'bin/automake')

--- a/controls/automake_exists.rb
+++ b/controls/automake_exists.rb
@@ -2,12 +2,12 @@ title 'Tests to confirm automake exists'
 
 plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'automake')
- 
+
 control 'core-plans-automake-exists' do
   impact 1.0
   title 'Ensure automake exists'
   desc '
-  Verify automake by ensuring /bin/automake exists'
+  Verify automake by ensuring bin/automake exists'
   
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
@@ -15,8 +15,8 @@ control 'core-plans-automake-exists' do
     its('stdout') { should_not be_empty }
   end
 
-  command_relative_path = input('command_relative_path', value: '/bin/automake')
-  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+  command_relative_path = input('command_relative_path', value: 'bin/automake')
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
   describe file(command_full_path) do
     it { should exist }
   end

--- a/controls/automake_exists.rb
+++ b/controls/automake_exists.rb
@@ -1,0 +1,22 @@
+title 'Tests to confirm automake exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'automake')
+ 
+control 'core-plans-automake-exists' do
+  impact 1.0
+  title 'Ensure automake exists'
+  desc '
+  '
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  command_relative_path = input('command_relative_path', value: '/bin/automake')
+  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+  describe file(command_full_path) do
+    it { should exist }
+  end
+end

--- a/controls/automake_works.rb
+++ b/controls/automake_works.rb
@@ -7,7 +7,10 @@ control 'core-plans-automake-works' do
   impact 1.0
   title 'Ensure automake works as expected'
   desc '
+  Verify automake by ensuring (1) its installation directory exists and (2) that
+  it returns the expected version
   '
+  
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }

--- a/controls/automake_works.rb
+++ b/controls/automake_works.rb
@@ -16,6 +16,7 @@ control 'core-plans-automake-works' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
   end
   
   command_relative_path = input('command_relative_path', value: 'bin/automake')

--- a/controls/automake_works.rb
+++ b/controls/automake_works.rb
@@ -1,0 +1,25 @@
+title 'Tests to confirm automake works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'automake')
+
+control 'core-plans-automake-works' do
+  impact 1.0
+  title 'Ensure automake works as expected'
+  desc '
+  '
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  
+  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
+  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} automake --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /automake \(GNU automake\) #{plan_pkg_version}/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/controls/automake_works.rb
+++ b/controls/automake_works.rb
@@ -7,8 +7,9 @@ control 'core-plans-automake-works' do
   impact 1.0
   title 'Ensure automake works as expected'
   desc '
-  Verify automake by ensuring (1) its installation directory exists and (2) that
-  it returns the expected version
+  Verify automake by ensuring 
+  (1) its installation directory exists and 
+  (2) that it returns the expected version.
   '
   
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
@@ -17,9 +18,10 @@ control 'core-plans-automake-works' do
     its('stdout') { should_not be_empty }
   end
   
-  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
-  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
-  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} automake --version") do
+  command_relative_path = input('command_relative_path', value: 'bin/automake')
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
+  plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
+  describe command("#{command_full_path} --version") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
     its('stdout') { should match /automake \(GNU automake\) #{plan_pkg_version}/ }

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,9 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
-maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
-copyright: humans@habitat.sh
-copyright_email: humans@habitat.sh
+name: automake
+title: Habitat Core Plan automake
+maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+summary: InSpec controls for testing Habitat Core Plan automake
+copyright: 2019, Chef Software, Inc.
+copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 3.0.25'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,41 @@
+pkg_name=automake
+pkg_origin=core
+pkg_version=1.16.1
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="\
+Automake is a tool for automatically generating Makefile.in files compliant \
+with the GNU Coding Standards.\
+"
+pkg_upstream_url="https://www.gnu.org/software/automake/"
+pkg_license=("GPL-2.0-or-later")
+pkg_source="http://ftp.gnu.org/gnu/${pkg_name}/${pkg_name}-${pkg_version}.tar.xz"
+pkg_shasum="5d05bb38a23fd3312b10aea93840feec685bdf4a41146e78882848165d3ae921"
+pkg_deps=(
+  core/perl
+)
+pkg_build_deps=(
+  core/autoconf
+  core/bison
+  core/coreutils
+  core/diffutils
+  core/flex
+  core/gcc
+  core/make
+)
+pkg_bin_dirs=(bin)
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(
+    core/gcc
+    core/coreutils
+    core/diffutils
+    core/autoconf
+  )
+fi

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,11 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Automake version command returns expected version" {
+  result="$(hab pkg exec "${TEST_PKG_IDENT}" automake --version | head -1 | cut -d' ' -f4)"
+  [ "$result" = "$TEST_PKG_VERSION"  ]
+}
+
+@test  "aclocal displays help" {
+  run hab pkg exec $TEST_PKG_IDENT aclocal --help
+  [ "$status" -eq 0 ]
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
### Outstanding tasks:
- [x] remove DEBUG
- [x] use full path to binary instead of hab pkg exec
- [x] parsing the pkg_version from the installation path.


```rspec
hab pkg exec chef/inspec inspec exec /src/. --chef-license=accept -t docker://632e656c19faa5fd5cef5faad360feef8ede890cceff57865224ab27530d235c --input-file /src/attributes.yml

Profile: Habitat Core Plan automake (automake)
Version: 0.1.0
Target:  docker://632e656c19faa5fd5cef5faad360feef8ede890cceff57865224ab27530d235c

  ✔  core-plans-automake-works: Ensure automake works as expected
     ✔  Command: `hab pkg path core/automake` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/automake` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/automake/1.16.1/20200603131638 automake --version` exit_status is expected to eq 0
     ✔  Command: `DEBUG=true; hab pkg exec core/automake/1.16.1/20200603131638 automake --version` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/automake/1.16.1/20200603131638 automake --version` stdout is expected to match /automake \(GNU automake\) 1.16.1/
     ✔  Command: `DEBUG=true; hab pkg exec core/automake/1.16.1/20200603131638 automake --version` stderr is expected to be empty
  ✔  core-plans-automake-exists: Ensure automake exists
     ✔  File /hab/pkgs/core/automake/1.16.1/20200603131638/bin/automake is expected to exist


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 7 successful, 0 failures, 0 skipped
+ set +x
```